### PR TITLE
Update repository URLs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "flexboxgrid-sass",
   "version": "8.0.0",
   "homepage": "https://github.com/tduarte/flexboxgrid-sass",
+  "homepage": "https://github.com/hugeinc/flexboxgrid-sass",
   "authors": [
     "@dam"
   ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/tduarte/flexboxgrid-sass.git"
+    "url": "git://github.com/hugeinc/flexboxgrid-sass.git"
   },
   "keywords": [
     "browser",
@@ -20,9 +20,9 @@
   "author": "@tduarte",
   "license": "Apache 2",
   "bugs": {
-    "url": "https://github.com/tduarte/flexboxgrid-sass/issues"
+    "url": "https://github.com/hugeinc/flexboxgrid-sass/issues"
   },
-  "homepage": "https://github.com/tduarte/flexboxgrid-sass",
+  "homepage": "https://github.com/hugeinc/flexboxgrid-sass",
   "devDependencies": {
     "autoprefixer-core": "^4.0.2",
     "del": "^1.1.1",


### PR DESCRIPTION
According to the changed repository URL this fixes the description URLs in `bower.json` and `package.json`
