### PR TITLE
Reinstate sass-flex-mixin dependency

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -2,7 +2,7 @@
 // -- Start editing -- //
 //
 
-@import "sass-flex-mixin/flexbox";
+@import "sass-flex-mixin/flex";
 
 // Set the number of columns you want to use on your layout.
 $grid-columns: 12;

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "st": "^0.5.4",
     "jade": "^1.11.0",
     "gulp-jade": "^1.1.0"
+  },
+  "dependencies": {
+    "sass-flex-mixin": "^1.0.0"
   }
 }


### PR DESCRIPTION
It looks like https://github.com/hugeinc/flexboxgrid-sass/commit/5f9ad3c20758ce1b9cee7e4f248d81ed63343ae1 lost the sass-flex-mixin dependency that https://github.com/hugeinc/flexboxgrid-sass/commit/ba50746cf1a8f8ae28ef8ea7f58b93683146ec7d introduced.

It also looks like 1.0.0 is the only sass-flex-mixin published to npm. Apparently the only change is to the mixin filename (`flex` vs `flexbox`), so I opted reverted to the 1.0.0 terminology.
- https://www.npmjs.com/package/sass-flex-mixin
- https://github.com/mastastealth/sass-flex-mixin/releases
