### PR TITLE
Refactor variables and selectors for easier consumption

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -2,7 +2,7 @@
 // -- Start editing -- //
 //
 
-@import "sass-flex-mixin/flexbox";
+@import "sass-flex-mixin/flex";
 
 // Set the number of columns you want to use on your layout.
 $grid-columns: 12;

--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -5,11 +5,11 @@
 @import "sass-flex-mixin/flex";
 
 // Set the number of columns you want to use on your layout.
-$grid-columns: 12;
+$grid-columns: 12 !default;
 // Set the gutter between columns.
-$gutter-width: 1rem;
+$gutter-width: 1rem !default;
 // Set a margin for the container sides.
-$outer-margin: 2rem;
+$outer-margin: 2rem !default;
 // Create or remove breakpoints for your project
 // Syntax:
 // name SIZErem,
@@ -17,14 +17,18 @@ $breakpoints:
   sm 48em 46rem,
   md 62em 61rem
   lg 75em 71rem;
+$flexboxgrid-max-width: 1200px !default;
 
 //
 // -- Stop editing -- //
 //
 
+$gutter-compensation: $gutter-width * .5 * -1;
+$half-gutter-width: $gutter-width * .5;
+
 .wrapper {
   box-sizing: border-box;
-  max-width: 1200px;
+  max-width: $flexboxgrid-max-width;
   margin: 0 auto;
 }
 
@@ -41,8 +45,8 @@ $breakpoints:
   @include flex(0, 1, auto);
   @include flex-direction(row);
   @include flex-wrap(wrap);
-  margin-right: -0.5rem;
-  margin-left: -0.5rem;
+  margin-right: $gutter-compensation;
+  margin-left: $gutter-compensation;
 }
 
 .row.reverse {
@@ -53,22 +57,28 @@ $breakpoints:
   @include flex-direction(column-reverse);
 }
 
-$name: xs;
-[class*="col-#{$name}"] {
+@mixin flexboxgrid-sass-col-common {
   box-sizing: border-box;
   @include flex(0, 0, auto);
-  padding-right: 0.5rem;
-  padding-left: 0.5rem;
+  padding-right: $half-gutter-width;
+  padding-left: $half-gutter-width;
+}
+
+$name: xs;
+.col-#{$name} {
+  @include flexboxgrid-sass-col-common;
 }
 @for $i from 1 through $grid-columns {
   .col-#{$name}-#{$i} {
+    @include flexboxgrid-sass-col-common;
     @include flex-basis(100% / $grid-columns * $i);
     max-width: 100% / $grid-columns * $i;
   }
 }
 @for $i from 1 through $grid-columns {
   .col-#{$name}-offset-#{$i} {
-    margin-left: 100% / $grid-columns * $i
+    @include flexboxgrid-sass-col-common;
+    margin-left: 100% / $grid-columns * $i;
   }
 }
 .col-#{$name} {
@@ -129,20 +139,19 @@ $name: xs;
       width: $container;
     }
 
-    [class*="col-#{$name}"] {
-      box-sizing: border-box;
-      @include flex(0, 0, auto);
-      padding-right: 0.5rem;
-      padding-left: 0.5rem;
+    .col-#{$name} {
+      @include flexboxgrid-sass-col-common;
     }
     @for $i from 1 through $grid-columns {
       .col-#{$name}-#{$i} {
+        @include flexboxgrid-sass-col-common;
         @include flex-basis(100% / $grid-columns * $i);
         max-width: 100% / $grid-columns * $i;
       }
     }
     @for $i from 1 through $grid-columns {
       .col-#{$name}-offset-#{$i} {
+        @include flexboxgrid-sass-col-common;
         margin-left: 100% / $grid-columns * $i
       }
     }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "st": "^0.5.4",
     "jade": "^1.11.0",
     "gulp-jade": "^1.1.0"
+  },
+  "dependencies": {
+    "sass-flex-mixin": "^1.0.0"
   }
 }


### PR DESCRIPTION
Requires https://github.com/hugeinc/flexboxgrid-sass/pull/6
- Respect existing config variable values via `!default`
- Use common mixin to disseminate col-$name-\* styles. This allows consuming
  scss with arbitrary class selectors to extend from classes like col-xs
  without losing gutter-width
- Restore usage of half-gutter-width to preserve relationship with gutter-width variable
- Restore usage of gutter-compensation to preserve relationship with gutter-width variable
