### PR TITLE
Fixing the path to the sass-flex-mixin

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -15,7 +15,7 @@ $outer-margin: 2rem !default;
 // name SIZErem,
 $breakpoints:
   sm 48em 46rem,
-  md 62em 61rem
+  md 62em 61rem,
   lg 75em 71rem;
 $flexboxgrid-max-width: 1200px !default;
 

--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -2,7 +2,7 @@
 // -- Start editing -- //
 //
 
-@import "sass-flex-mixin/flex";
+@import "../sass-flex-mixin/flex";
 
 // Set the number of columns you want to use on your layout.
 $grid-columns: 12 !default;


### PR DESCRIPTION
With npm 3 all deps are in the root directory. Additionally, a missing comma would prevent the `col-lg` to be created.
