### PR TITLE
allow $breakpoints to be overridden

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -16,7 +16,7 @@ $outer-margin: 2rem !default;
 $breakpoints:
   sm 48em 46rem,
   md 62em 61rem,
-  lg 75em 71rem;
+  lg 75em 71rem !default;
 $flexboxgrid-max-width: 1200px !default;
 
 //


### PR DESCRIPTION
Looks like an upstream merge may have removed the `!default` flag.
