### PR TITLE
update @import for sass-flex-mixin 1.0.3 breaking change

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -2,7 +2,7 @@
 // -- Start editing -- //
 //
 
-@import "../sass-flex-mixin/_flexbox";
+@import "../sass-flex-mixin/_flex";
 
 // Set the number of columns you want to use on your layout.
 $grid-columns: 12 !default;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "gulp-jade": "^1.1.0"
   },
   "dependencies": {
-    "sass-flex-mixin": "^1.0.0"
+    "sass-flex-mixin": "^1.0.3"
   }
 }


### PR DESCRIPTION
In [sass-flex-mixin 1.0.3](https://github.com/mastastealth/sass-flex-mixin/commit/a4d4b5daf6eb6260878acef65ac32824f2a14bb0), the name of the main file was reverted back to `_flex.scss`, but semver was not respected, which broke the dependency here. This should clear it up. 
