### PR TITLE
Use values left and right instead of start and end

### DIFF
--- a/flexboxgrid.scss
+++ b/flexboxgrid.scss
@@ -101,7 +101,7 @@ $name: xs;
 }
 .start-#{$name} {
   @include justify-content(flex-start);
-  text-align: start;
+  text-align: left;
 }
 
 .center-#{$name} {
@@ -111,7 +111,7 @@ $name: xs;
 
 .end-#{$name} {
   @include justify-content(flex-end);
-  text-align: end;
+  text-align: right;
 }
 
 .top-#{$name} {
@@ -180,7 +180,7 @@ $name: xs;
     }
     .start-#{$name} {
       @include justify-content(flex-start);
-      text-align: start;
+      text-align: left;
     }
 
     .center-#{$name} {
@@ -190,7 +190,7 @@ $name: xs;
 
     .end-#{$name} {
       @include justify-content(flex-end);
-      text-align: end;
+      text-align: right;
     }
 
     .top-#{$name} {


### PR DESCRIPTION
The `start` and `end` values are not supported in IE11. 
On the [mozilla site](https://developer.mozilla.org/nl/docs/Web/CSS/text-align) they also say its experimental and shouldn't be used in production